### PR TITLE
Make async presentTransact awaitable

### DIFF
--- a/ios/Classes/SwiftAtomicTransactFlutterPlugin.swift
+++ b/ios/Classes/SwiftAtomicTransactFlutterPlugin.swift
@@ -31,6 +31,9 @@ public class SwiftAtomicTransactFlutterPlugin: NSObject, FlutterPlugin {
                     if let controller = UIApplication.shared.windows.filter({$0.isKeyWindow}).first?.rootViewController {
                         Atomic.presentTransact(from: controller, config: config, environment: environment,
                                                onInteraction: onInteraction, onDataRequest: onDataRequest, onCompletion: onCompletion)
+                        result(nil)
+                    } else {
+                        result(FlutterError(code: "PlatformError", message: "No keyWindow found"))
                     }
                 } catch let error {
                     result(FlutterError(code: "ConfigError", message: String(describing: error), details: nil))

--- a/ios/Classes/SwiftAtomicTransactFlutterPlugin.swift
+++ b/ios/Classes/SwiftAtomicTransactFlutterPlugin.swift
@@ -33,7 +33,7 @@ public class SwiftAtomicTransactFlutterPlugin: NSObject, FlutterPlugin {
                                                onInteraction: onInteraction, onDataRequest: onDataRequest, onCompletion: onCompletion)
                         result(nil)
                     } else {
-                        result(FlutterError(code: "PlatformError", message: "No keyWindow found"))
+                        result(FlutterError(code: "PlatformError", message: "No keyWindow found", details: nil))
                     }
                 } catch let error {
                     result(FlutterError(code: "ConfigError", message: String(describing: error), details: nil))


### PR DESCRIPTION
presentTransact's native implementation on iOS was never calling the result callback in the success case, resulting in await never returning to the dart code calling this function.