### PR TITLE
fix(dependency)

### DIFF
--- a/ios/atomic_transact_flutter.podspec
+++ b/ios/atomic_transact_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'atomic_transact_flutter'
-  s.version          = '0.0.1'
+  s.version          = '1.2.1'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -22,6 +22,6 @@ A new flutter plugin project.
   s.swift_version = '5.0'
 
   # Atomic dependency
-  s.dependency 'AtomicSDK', '~> 2'
+  s.dependency 'AtomicSDK', '~>2', '!= 2.5.1'
 
 end


### PR DESCRIPTION
The iOS SDK version 2.5.1 is not building, this will keep the same logic for versioning, but not use the broken version.

The error when building 2.5.1:

> [!] The 'Pods-Runner' target has transitive dependencies that include statically linked binaries: (/Users/builder/clone/ios/Pods/AtomicSDK/artifacts/AtomicTransact.xcframework)