### PR TITLE
chore: update iOS sdk to 3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.0
+
+- Add support for iOS SDK v3.11.0
+
 ## 3.10.0
 
 - Add support for iOS SDK v3.10.0 with background task fix

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - atomic_transact_flutter (3.10.0):
-    - AtomicSDK (= 3.10.0)
+    - AtomicSDK (= 3.11.0)
     - Flutter
-  - AtomicSDK (3.10.0):
-    - QuantumIOS (= 3.10.0)
+  - AtomicSDK (3.11.0):
+    - QuantumIOS (= 3.11.0)
   - Flutter (1.0.0)
-  - QuantumIOS (3.10.0):
-    - QuantumIOS/QuantumIOS (= 3.10.0)
-  - QuantumIOS/MuppetIOS (3.10.0)
-  - QuantumIOS/QuantumIOS (3.10.0):
+  - QuantumIOS (3.11.0):
+    - QuantumIOS/QuantumIOS (= 3.11.0)
+  - QuantumIOS/MuppetIOS (3.11.0)
+  - QuantumIOS/QuantumIOS (3.11.0):
     - QuantumIOS/MuppetIOS
 
 DEPENDENCIES:
@@ -27,10 +27,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  atomic_transact_flutter: cab8babc20e848744d6799d03681a9d1606a4687
-  AtomicSDK: c81c01db29fb0347727867290d1e4cfd7f07b3a3
+  atomic_transact_flutter: 3be6c9f262ea465c1559f6b5b34200643c6b12d9
+  AtomicSDK: 2e21ad3aee0f8271a35c812f8a575e6cbeb184ba
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  QuantumIOS: 630d00a6929ffbe985ff919082d7a2f4bf4fa758
+  QuantumIOS: 2dcabb7fd77a51b3c6c2c822b5dd5c1c3e726f93
 
 PODFILE CHECKSUM: 775997f741c536251164e3eacf6e34abf2eb7a17
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.10.0"
+    version: "3.11.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/atomic_transact_flutter.podspec
+++ b/ios/atomic_transact_flutter.podspec
@@ -23,6 +23,6 @@ A new flutter plugin project.
   s.swift_version = '5.0'
 
   # Atomic dependency
-  s.dependency 'AtomicSDK', '3.10.0'
+  s.dependency 'AtomicSDK', '3.11.0'
 
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atomic_transact_flutter
 description: A Flutter plugin that provides a native implementation for the Atomic Transact SDK.
-version: 3.10.0
+version: 3.11.0
 repository: https://github.com/atomicfi/atomic-transact-flutter
 
 environment:


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/MGMT-583/transact-should-send-cleanup-application-event-when-all-tasks-are

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
  - A01:2021-Broken Access Control
  - A02:2021-Cryptographic Failures
  - A03:2021-Injection
  - A04:2021-Insecure Design
  - A05:2021-Security Misconfiguration
  - A06:2021-Vulnerable and Outdated Components
  - A07:2021-Identification and Authentication Failures
  - A08:2021-Software and Data Integrity Failures
  - A09:2021-Security Logging and Monitoring Failures
  - A10:2021-Server-Side Request Forgery
