### PR TITLE
fix: allow name in onInteraction event to be null

### DIFF
--- a/android/src/main/kotlin/atomic/financial/atomic_transact_flutter/AtomicTransactFlutterPlugin.kt
+++ b/android/src/main/kotlin/atomic/financial/atomic_transact_flutter/AtomicTransactFlutterPlugin.kt
@@ -283,18 +283,29 @@ class AtomicTransactFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
 
   private fun mapFromTransactInteraction(data: JSONObject): Map<String, Any?> {
     val result = mutableMapOf<String, Any?>();
-    val name = data.getString("name")
-    val value = data.getJSONObject("value")
+    val name = data.optString("name")
+    val value = data.optJSONObject("value")
 
     result["name"] = name
-    result["identifier"] = value.optString("identifier")
-    result["customer"] = value.optString("customer")
-    result["language"] = value.optString("language")
-    result["product"] = value.optString("product")
-    result["additionalProduct"] = value.optString("additionalProduct")
-    result["payroll"] = value.optString("payroll")
-    result["company"] = value.optString("company")
-    result["value"] = toMap(value)
+    if (value != null) {
+      result["identifier"] = value.optString("identifier")
+      result["customer"] = value.optString("customer")
+      result["language"] = value.optString("language")
+      result["product"] = value.optString("product")
+      result["additionalProduct"] = value.optString("additionalProduct")
+      result["payroll"] = value.optString("payroll")
+      result["company"] = value.optString("company")
+      result["value"] = toMap(value)
+    } else {
+      result["identifier"] = ""
+      result["customer"] = ""
+      result["language"] = ""
+      result["product"] = ""
+      result["additionalProduct"] = ""
+      result["payroll"] = ""
+      result["company"] = ""
+      result["value"] = null
+    }
 
     return result.toMap()
   }


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/MGMT-1017/flutter-sdk-is-crashing-on-android

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
  - A01:2021-Broken Access Control
  - A02:2021-Cryptographic Failures
  - A03:2021-Injection
  - A04:2021-Insecure Design
  - A05:2021-Security Misconfiguration
  - A06:2021-Vulnerable and Outdated Components
  - A07:2021-Identification and Authentication Failures
  - A08:2021-Software and Data Integrity Failures
  - A09:2021-Security Logging and Monitoring Failures
  - A10:2021-Server-Side Request Forgery
