### PR TITLE
chore: bump ios transact sdk to 3.20.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.13.3
+
+- Add support for iOS SDK v3.20.5
+
 ## 3.13.2
 
 - Add support for Android SDK v3.11.4

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - atomic_transact_flutter (3.10.0):
-    - AtomicSDK (= 3.20.0)
+    - AtomicSDK (= 3.20.5)
     - Flutter
-  - AtomicSDK (3.20.0)
+  - AtomicSDK (3.20.5)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  atomic_transact_flutter: 5b0dd17ef098f9d5d4801c423717f144a5a37242
-  AtomicSDK: 0f28dc75a8dcc75bb4ee62bda65e9436e3cfaf7f
+  atomic_transact_flutter: fb5a7e3d74a2ed44c9477c8f7b08a3d51659c5fb
+  AtomicSDK: 8f1f770c7be40dfa75e266f3f35311fe0a04cd08
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 
 PODFILE CHECKSUM: 775997f741c536251164e3eacf6e34abf2eb7a17

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -43,6 +44,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.13.1"
+    version: "3.13.3"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/atomic_transact_flutter.podspec
+++ b/ios/atomic_transact_flutter.podspec
@@ -23,6 +23,6 @@ A new flutter plugin project.
   s.swift_version = '5.0'
 
   # Atomic dependency
-  s.dependency 'AtomicSDK', '3.20.0'
+  s.dependency 'AtomicSDK', '3.20.5'
 
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atomic_transact_flutter
 description: A Flutter plugin that provides a native implementation for the Atomic Transact SDK.
-version: 3.13.2
+version: 3.13.3
 repository: https://github.com/atomicfi/atomic-transact-flutter
 
 environment:


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-69/release-flutter-sdk-3133

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
  - A01:2021-Broken Access Control
  - A02:2021-Cryptographic Failures
  - A03:2021-Injection
  - A04:2021-Insecure Design
  - A05:2021-Security Misconfiguration
  - A06:2021-Vulnerable and Outdated Components
  - A07:2021-Identification and Authentication Failures
  - A08:2021-Software and Data Integrity Failures
  - A09:2021-Security Logging and Monitoring Failures
  - A10:2021-Server-Side Request Forgery
