### PR TITLE
chore: update to use ios sdk 3.20.6 and android sdk 3.11.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "financial.atomic:transact:3.11.4"
+    implementation "financial.atomic:transact:3.11.5"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - atomic_transact_flutter (3.10.0):
-    - AtomicSDK (= 3.20.5)
+  - atomic_transact_flutter (3.13.4):
+    - AtomicSDK (= 3.20.6)
     - Flutter
-  - AtomicSDK (3.20.5)
+  - AtomicSDK (3.20.6)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  atomic_transact_flutter: fb5a7e3d74a2ed44c9477c8f7b08a3d51659c5fb
-  AtomicSDK: 8f1f770c7be40dfa75e266f3f35311fe0a04cd08
+  atomic_transact_flutter: c8333dbca7d917541c8b4067f82e010547932392
+  AtomicSDK: 443002b2bc7d5434d05195c79b574b7c0f160577
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 
 PODFILE CHECKSUM: 775997f741c536251164e3eacf6e34abf2eb7a17

--- a/ios/atomic_transact_flutter.podspec
+++ b/ios/atomic_transact_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'atomic_transact_flutter'
-  s.version          = '3.10.0'
+  s.version          = '3.13.4'
   s.summary          = 'Atomic Flutter SDK'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -23,6 +23,6 @@ A new flutter plugin project.
   s.swift_version = '5.0'
 
   # Atomic dependency
-  s.dependency 'AtomicSDK', '3.20.5'
+  s.dependency 'AtomicSDK', '3.20.6'
 
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: atomic_transact_flutter
 description: A Flutter plugin that provides a native implementation for the Atomic Transact SDK.
-version: 3.13.3
+version: 3.13.4
 repository: https://github.com/atomicfi/atomic-transact-flutter
 
 environment:


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-87/upgrade-flutter-sdk-to-use-ios-3206-and-android-3115

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
  - A01:2021-Broken Access Control
  - A02:2021-Cryptographic Failures
  - A03:2021-Injection
  - A04:2021-Insecure Design
  - A05:2021-Security Misconfiguration
  - A06:2021-Vulnerable and Outdated Components
  - A07:2021-Identification and Authentication Failures
  - A08:2021-Software and Data Integrity Failures
  - A09:2021-Security Logging and Monitoring Failures
  - A10:2021-Server-Side Request Forgery
