### PR TITLE
feat: send Flutter plugin version as platform suffix to native SDKs 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,16 @@ jobs:
           NEW_VERSION="${NEW_VERSION#v}"
           ./scripts/bump_version.sh --version "$NEW_VERSION"
 
+      - name: Verify version sync
+        run: |
+          PUBSPEC_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
+          DART_VERSION=$(grep "packageVersion" lib/src/version.dart | sed "s/.*'\(.*\)'.*/\1/")
+          if [ "$PUBSPEC_VERSION" != "$DART_VERSION" ]; then
+            echo "::error::Version mismatch: pubspec.yaml ($PUBSPEC_VERSION) != lib/src/version.dart ($DART_VERSION)"
+            exit 1
+          fi
+          echo "Versions in sync: $PUBSPEC_VERSION"
+
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/android/src/main/kotlin/atomic/financial/atomic_transact_flutter/AtomicTransactFlutterPlugin.kt
+++ b/android/src/main/kotlin/atomic/financial/atomic_transact_flutter/AtomicTransactFlutterPlugin.kt
@@ -34,6 +34,8 @@ class AtomicTransactFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     if (call.method == "presentTransact") {
       val transactPath = call.argument<String>("transactPath") as String? ?: ""
       val apiPath = call.argument<String>("apiPath") as String? ?: ""
+      val pluginVersion = call.argument<String>("pluginVersion") ?: ""
+      val suffix = if (pluginVersion.isNotEmpty()) "flutter-$pluginVersion" else "flutter"
       val debug = call.argument<Boolean>("debug") ?: false
       val configuration = call.argument<Map<String, Any>>("configuration")
       val publicToken = configuration?.get("publicToken") as String
@@ -71,6 +73,8 @@ class AtomicTransactFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
           webContentsDebuggingEnabled = debug
         )
 
+      config.platform = Config.Platform.suffixed(suffix)
+
       Transact.registerReceiver(activity, object: TransactBroadcastReceiver() {
         override fun onClose(data: JSONObject) {
           channel.invokeMethod("onCompletion", mapOf("type" to "closed", "response" to mapFromTransactResponseData(data)));
@@ -93,11 +97,13 @@ class AtomicTransactFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
       })
 
       Transact.present(activity, config)
-    } 
+    }
     else if (call.method == "presentAction") {
       val id = call.argument<String>("id") ?: return
       val transactPath = call.argument<String>("transactPath") as String? ?: ""
       val apiPath = call.argument<String>("apiPath") as String? ?: ""
+      val actionPluginVersion = call.argument<String>("pluginVersion") ?: ""
+      val actionSuffix = if (actionPluginVersion.isNotEmpty()) "flutter-$actionPluginVersion" else "flutter"
       val debug = call.argument<Boolean>("debug") ?: false
       var theme = call.argument<Map<String, Any>>("theme")
       val config = ActionConfig(
@@ -107,6 +113,7 @@ class AtomicTransactFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
         theme = configThemeFromMap(theme),
         webContentsDebuggingEnabled = debug
       )
+      config.platform = Config.Platform.suffixed(actionSuffix)
 
       Transact.registerReceiver(activity, object: TransactBroadcastReceiver() {
         override fun onClose(data: JSONObject) {

--- a/ios/atomic_transact_flutter/Sources/atomic_transact_flutter/AtomicTransactFlutterPlugin.swift
+++ b/ios/atomic_transact_flutter/Sources/atomic_transact_flutter/AtomicTransactFlutterPlugin.swift
@@ -23,6 +23,7 @@ public class AtomicTransactFlutterPlugin: NSObject, FlutterPlugin {
             let arguments = call.arguments as! [String: Any]
             let transactPath = arguments["transactPath"] as! String
             let apiPath = arguments["apiPath"] as! String
+            let pluginVersion = arguments["pluginVersion"] as? String ?? ""
             let debugEnabled = arguments["debug"] as? Bool ?? false
             let decoder = JSONDecoder()
 
@@ -31,11 +32,8 @@ public class AtomicTransactFlutterPlugin: NSObject, FlutterPlugin {
             if let configuration = arguments["configuration"] as? [String: Any] {
                 do {
                     var json = configuration
-
-                    if var platform = AtomicConfig.Platform().encode() as? [String: Any] {
-                        platform["sdkVersion"] = platform["sdkVersion"] as! String + "-flutter"
-                        json["platform"] = platform
-                    }
+                    let suffix = pluginVersion.isEmpty ? "flutter" : "flutter-\(pluginVersion)"
+                    json["platform"] = AtomicConfig.Platform(suffixed: suffix).encode()
 
                     guard let data = try? JSONSerialization.data(withJSONObject: json, options: []) else { return }
 

--- a/lib/platform_interface/atomic_method_channel.dart
+++ b/lib/platform_interface/atomic_method_channel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 
 import '../src/config.dart';
 import '../src/types.dart';
+import '../src/version.dart';
 import 'atomic_platform_interface.dart';
 
 class AtomicMethodChannel extends AtomicPlatformInterface {
@@ -31,6 +32,7 @@ class AtomicMethodChannel extends AtomicPlatformInterface {
         'transactPath': environment.transactPath,
         'apiPath': environment.apiPath,
         'presentationStyleIOS': presentationStyleIOS?.name,
+        'pluginVersion': packageVersion,
         'debug': debug,
       },
     );
@@ -52,6 +54,7 @@ class AtomicMethodChannel extends AtomicPlatformInterface {
       'apiPath': environment.apiPath,
       'theme': theme?.toJson(),
       'presentationStyleIOS': presentationStyleIOS?.name,
+      'pluginVersion': packageVersion,
       'debug': debug,
     });
   }

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 
-import 'dart:io' show Platform;
-
 import 'types.dart';
 
 /// Provide colors to customize Transact.
@@ -424,12 +422,6 @@ class AtomicConfig {
   /// Handoff allows views to be handled outside of Transact.
   final List<AtomicTransactHandoff>? handoff;
 
-  /// The platform being used
-  final Map<String, String> platform = {
-    'version': Platform.operatingSystemVersion,
-    'name': Platform.operatingSystem
-  };
-
   /// Used to override feature flags
   final AtomicExperiments? experiments;
 
@@ -467,7 +459,6 @@ class AtomicConfig {
       'linkedAccount': linkedAccount,
       'theme': theme?.toJson(),
       'language': language,
-      'platform': platform,
       'deeplink': deeplink?.toJson(),
       'metadata': metadata,
       'search': search?.toJson(),

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,3 @@
+// GENERATED — do not edit by hand.
+// Updated by scripts/bump_version.sh
+const String packageVersion = '3.13.4';

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -4,6 +4,7 @@ set -e
 
 PUBSPEC_FILE="pubspec.yaml"
 PODSPEC_FILE="ios/atomic_transact_flutter.podspec"
+VERSION_DART_FILE="lib/src/version.dart"
 CHANGELOG_FILE="CHANGELOG.md"
 
 NEW_VERSION=""
@@ -113,6 +114,13 @@ rm "$PUBSPEC_FILE.bak"
 sed -i.bak "s/s\.version *= *'[^']*'/s.version          = '$new_version'/" "$PODSPEC_FILE"
 rm "$PODSPEC_FILE.bak"
 
+# Update version.dart
+cat > "$VERSION_DART_FILE" << DART
+// GENERATED — do not edit by hand.
+// Updated by scripts/bump_version.sh
+const String packageVersion = '$new_version';
+DART
+
 # Update changelog
 update_changelog "$new_version"
 
@@ -120,4 +128,5 @@ echo "✅ Successfully updated version to $new_version in all files"
 echo "📝 Updated files:"
 echo "  - $PUBSPEC_FILE"
 echo "  - $PODSPEC_FILE"
+echo "  - $VERSION_DART_FILE"
 echo "  - $CHANGELOG_FILE"


### PR DESCRIPTION
# Linear Link

https://linear.app/atomicbuilt/issue/SDK-513/update-version-string-in-flutter-sdk
https://linear.app/atomicbuilt/issue/SDK-400/flutter-android-missing-flutter-version-suffix

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which cleans up code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change impacts security

# Checklist:

- [ ] New and existing tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on a physical iOS device and Android device
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have followed the [Code Review](https://www.notion.so/atomicfi/Code-Reviews-4c05c97bdbbe4d3aa3c6c72ca7e0d57f) and [Code Review Security](https://www.notion.so/atomicfi/Security-bbfb3b07c7494f70ac0f6f47120b10ef) guidelines
- [x] I have checked my code against flaws from the [OWASP Top 10](https://owasp.org/www-project-top-ten/)
  - A01:2021-Broken Access Control
  - A02:2021-Cryptographic Failures
  - A03:2021-Injection
  - A04:2021-Insecure Design
  - A05:2021-Security Misconfiguration
  - A06:2021-Vulnerable and Outdated Components
  - A07:2021-Identification and Authentication Failures
  - A08:2021-Software and Data Integrity Failures
  - A09:2021-Security Logging and Monitoring Failures
  - A10:2021-Server-Side Request Forgery
